### PR TITLE
feat(migrate-legacy) Migrate Reusable Components in Angular post

### DIFF
--- a/_posts/reusable-components-in-angular.md
+++ b/_posts/reusable-components-in-angular.md
@@ -1,0 +1,23 @@
+---
+title: "Reusable components in Angular"
+date: "2015-02-10"
+author: Rachael L Moore
+category: engineering
+---
+
+### Talk abstract
+
+Distributable user interface components combining HTML, CSS, and JavaScript are going to change user interface architecture on the web. However, web component specifications are still in progress and full adoption relies on using polyfills for evolving and still much-debated native features.
+
+Fortunately, AngularJS lets us leverage the UI components paradigm while we wait. With AngularJS directives and services and a little build-time magic, it’s possible implement fully featured UI components without web component polyfills. We’ll talk about how we are designing these UI components and highlight some important AngularJS-specific techniques for building them.
+
+### Speaker Bios
+
+Rachael L Moore is a UI Engineer at OpenTable specializing in the implementation of enterprise-scale graphical interfaces using HTML, CSS, and JavaScript. She joined OpenTable in 2014, after doing freelance web design in the 90’s and 7 years at Homes.com.
+
+Kara Erickson is a Software Engineer at OpenTable where she builds Angular applications for OpenTable restaurants. She has spent the last six months architecting a robust library of business-level and UI-level components founded on Angular directives.
+
+[![Reusable Components in Angular: Design patterns, transclusion, and more](http://img.youtube.com/vi/dF_ObGgzGE8/0.jpg)](http://www.youtube.com/watch?v=dF_ObGgzGE8 "Reusable Components in Angular: Design patterns, transclusion, and more")
+
+Slides and speaker notes are available [here](https://docs.google.com/presentation/d/1ozBlL1MXxyYPSLzIaMtHO1YF-tHkEzKFsvt4s3rBBt0/).
+


### PR DESCRIPTION
Migrated [this post](https://tech.opentable.com/reusable-components-angular/) to our US tech blog repo/site.